### PR TITLE
Change all occurences from /v1/ to /v2/.

### DIFF
--- a/.Rproj.user/DC33445C/sources/s-8812577A/1D0D1931-contents
+++ b/.Rproj.user/DC33445C/sources/s-8812577A/1D0D1931-contents
@@ -42,7 +42,7 @@ translate_vec <- function(dataset = NULL,
                       target.lang = "EN",
                       add.source.lang = FALSE,
                       auth_key = NULL,
-                      url = "https://api.deepl.com/v1/translate?text="
+                      url = "https://api.deepl.com/v2/translate?text="
                       ) {
 
 

--- a/.Rproj.user/DC33445C/sources/s-8812577A/F27A9EBB-contents
+++ b/.Rproj.user/DC33445C/sources/s-8812577A/F27A9EBB-contents
@@ -49,7 +49,7 @@ translate_df <- function(dataset = NULL,
                       target.lang = "EN",
                       add.source.lang = FALSE,
                       auth_key = NULL,
-                      url = "https://api.deepl.com/v1/translate?text="
+                      url = "https://api.deepl.com/v2/translate?text="
                       ) {
 
 

--- a/R/translate.R
+++ b/R/translate.R
@@ -3,7 +3,7 @@ translate <- function(dataset = NULL,
                       source.lang = "DE",
                       target.lang = "EN",
                       auth_key = NULL,
-                      url = "https://api.deepl.com/v1/translate?text="
+                      url = "https://api.deepl.com/v2/translate?text="
                       ) {
 
 

--- a/R/translate_df.R
+++ b/R/translate_df.R
@@ -49,7 +49,7 @@ translate_df <- function(dataset = NULL,
                       target.lang = "EN",
                       add.source.lang = FALSE,
                       auth_key = NULL,
-                      url = "https://api.deepl.com/v1/translate?text="
+                      url = "https://api.deepl.com/v2/translate?text="
                       ) {
 
 

--- a/R/translate_vec.R
+++ b/R/translate_vec.R
@@ -42,7 +42,7 @@ translate_vec <- function(dataset = NULL,
                       target.lang = "EN",
                       add.source.lang = FALSE,
                       auth_key = NULL,
-                      url = "https://api.deepl.com/v1/translate?text="
+                      url = "https://api.deepl.com/v2/translate?text="
                       ) {
 
 

--- a/man/translate_df.Rd
+++ b/man/translate_df.Rd
@@ -6,7 +6,7 @@
 \usage{
 translate_df(dataset = NULL, column.name = NULL, source.lang = "DE",
   target.lang = "EN", add.source.lang = FALSE, auth_key = NULL,
-  url = "https://api.deepl.com/v1/translate?text=")
+  url = "https://api.deepl.com/v2/translate?text=")
 }
 \arguments{
 \item{dataset}{Dataframe with column of class character.}

--- a/man/translate_vec.Rd
+++ b/man/translate_vec.Rd
@@ -6,7 +6,7 @@
 \usage{
 translate_vec(dataset = NULL, source.lang = "DE", target.lang = "EN",
   add.source.lang = FALSE, auth_key = NULL,
-  url = "https://api.deepl.com/v1/translate?text=")
+  url = "https://api.deepl.com/v2/translate?text=")
 }
 \arguments{
 \item{dataset}{A character vector.}


### PR DESCRIPTION
As per the updated price model, DeepL API should use the /v2/ endpoint for the API:

> version 1 of the DeepL API is not supported by the DeepL API plan available starting October 2018. Please use version v2 for all new products except CAT tool integrations.

source: https://www.deepl.com/api.html